### PR TITLE
Add option to keep the foreground service alive

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ It allows access to the same brightness levels as Google Magnifier, except witho
 * Only supports Android 15+. For Android 12-14, use the old PixelLight 1.0 release, which has a better user experience due to fewer Android restrictions.
 * On Android 15, the quick settings tile requires unlocking the device when used on the lock screen. The quick settings panel will also close when tapping on the tile. These are not fixable due to Android 15's new restrictions on starting foreground services.
 
+  However, if the "Keep service alive" option is enabled, then these restrictions only apply the first time the tile is toggled after a reboot. This keeps the foreground service running indefinitely, but does not impact battery life because the service is completely idle and not executing any code. The mandatory notification can be disabled from Android's settings if desired.
+
 ## Permissions
 
 The `CAMERA` permission is required because Pixel's private API for high brightness modes is only accessible when using the camera as a camera, not when using the camera as a flashlight with the official Android 13+ APIs. Internally, PixelLight is taking a picture every time the flashlight is turned on or the brightness is changed. These exist only in memory and are never saved to disk.

--- a/app/src/main/java/com/chiller3/pixellight/MainActivity.java
+++ b/app/src/main/java/com/chiller3/pixellight/MainActivity.java
@@ -13,6 +13,8 @@ import android.content.ServiceConnection;
 import android.content.pm.PackageManager;
 import android.os.Bundle;
 import android.os.IBinder;
+import android.view.Menu;
+import android.view.MenuItem;
 import android.view.View;
 import android.widget.CompoundButton;
 import android.widget.SeekBar;
@@ -50,6 +52,33 @@ public class MainActivity extends Activity implements ServiceConnection, TorchSe
 
         binding.requestPermissions.setOnClickListener(v ->
             requestPermissions(Permissions.REQUIRED, REQUEST_PERMISSIONS));
+    }
+
+    @Override
+    public boolean onCreateOptionsMenu(Menu menu) {
+        getMenuInflater().inflate(R.menu.main_activity_options, menu);
+
+        menu.findItem(R.id.keep_service_alive).setChecked(prefs.getKeepServiceAlive());
+
+        return super.onCreateOptionsMenu(menu);
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(@NonNull MenuItem item) {
+        if (item.getItemId() == R.id.keep_service_alive) {
+            item.setChecked(!item.isChecked());
+            prefs.setKeepServiceAlive(item.isChecked());
+
+            if (!item.isChecked() && torchBinder != null) {
+                // Try to shut down the service so that the user doesn't have to manually turn the
+                // torch on and off for the change to take effect.
+                torchBinder.tryStopService();
+            }
+
+            return true;
+        } else {
+            return super.onOptionsItemSelected(item);
+        }
     }
 
     @Override

--- a/app/src/main/java/com/chiller3/pixellight/Preferences.java
+++ b/app/src/main/java/com/chiller3/pixellight/Preferences.java
@@ -13,6 +13,7 @@ import androidx.annotation.NonNull;
 
 public class Preferences {
     private static final String PREF_BRIGHTNESS = "brightness";
+    private static final String PREF_KEEP_SERVICE_ALIVE = "keep_service_alive";
 
     private final SharedPreferences prefs;
 
@@ -26,5 +27,13 @@ public class Preferences {
 
     public void setBrightness(int value) {
         prefs.edit().putInt(PREF_BRIGHTNESS, value).apply();
+    }
+
+    public boolean getKeepServiceAlive() {
+        return prefs.getBoolean(PREF_KEEP_SERVICE_ALIVE, false);
+    }
+
+    public void setKeepServiceAlive(boolean keep) {
+        prefs.edit().putBoolean(PREF_KEEP_SERVICE_ALIVE, keep).apply();
     }
 }

--- a/app/src/main/java/com/chiller3/pixellight/TorchTileService.java
+++ b/app/src/main/java/com/chiller3/pixellight/TorchTileService.java
@@ -85,12 +85,18 @@ public class TorchTileService extends TileService implements ServiceConnection, 
             newBrightness = 0;
         }
 
-        final var serviceIntent = TorchService.createSetBrightnessIntent(this, newBrightness);
-        final var intent = FgsLauncherActivity.createIntent(this, serviceIntent);
+        if (torchBinder.isInForeground()) {
+            // With Android 15, we can't start a camera foreground service from a tile service
+            // anymore, but we can connect to a previously started instance just fine.
+            torchBinder.setTorchBrightness(newBrightness);
+        } else {
+            final var serviceIntent = TorchService.createSetBrightnessIntent(this, newBrightness);
+            final var intent = FgsLauncherActivity.createIntent(this, serviceIntent);
 
-        startActivityAndCollapse(PendingIntent.getActivity(
-                this, 0, intent,
-                PendingIntent.FLAG_IMMUTABLE | PendingIntent.FLAG_UPDATE_CURRENT));
+            startActivityAndCollapse(PendingIntent.getActivity(
+                    this, 0, intent,
+                    PendingIntent.FLAG_IMMUTABLE | PendingIntent.FLAG_UPDATE_CURRENT));
+        }
 
         // The tile state will be changed when onTorchStateChanged() is called.
     }

--- a/app/src/main/res/menu/main_activity_options.xml
+++ b/app/src/main/res/menu/main_activity_options.xml
@@ -1,0 +1,9 @@
+<!--
+    SPDX-FileCopyrightText: 2024 Andrew Gunnerson
+    SPDX-License-Identifier: GPL-3.0-only
+-->
+<menu xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:id="@+id/keep_service_alive"
+        android:title="@string/menu_keep_service_alive"
+        android:checkable="true" />
+</menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -6,6 +6,8 @@
     <string name="permissions_name">Request permissions</string>
     <string name="permissions_desc">The camera permission is required to access the private Google Pixel API for using the full brightness range. The notification permission is required to keep the flashlight on in the background.</string>
 
+    <string name="menu_keep_service_alive">Keep service alive</string>
+
     <string name="notification_channel_persistent_name">Background services</string>
     <string name="notification_channel_persistent_desc">Persistent notification required for running in the background</string>
     <string name="notification_channel_error_name">Errors</string>


### PR DESCRIPTION
This restores 1.x's user experience aside from the first use of the quick settings tile after a reboot. When the option is enabled, the quick settings tile can reconnect to the existing foreground service, bypassing Android's restrictions since they only apply to starting new foreground services that use the camera.

Issue: #9