### PR TITLE
Pretend to be note-taking app

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ It allows access to the same brightness levels as Google Magnifier, except witho
 
 * Supports entire brightness range
 * Quick settings tile
+* [Lock screen shortcut](#lock-screen-shortcut)
 * Tiny APK with no dependencies
 
 ## Limitations
@@ -44,7 +45,19 @@ This activity accepts an optional integer parameter named `brightness`:
 
 ## Lock screen shortcut
 
-Android currently has no builtin way to set custom lock screen shortcuts. To use PixelLight in a lock screen shortcut, the system QR code scanner app must be overridden to point to PixelLight's `ToggleActivity`:
+Android currently has no builtin way to set custom lock screen shortcuts. To use PixelLight with a lock screen shortcut, it's necessary to either set it as the default note taking app or override the QR code scanner shortcut. The note taking app approach is preferred since it doesn't result in janky animations or black screen issues.
+
+### Set as default note taking app
+
+Android currently doesn't enable the note taking app role by default. It must first be enabled via the `Force enable Notes role` setting in Android's developer options (underneath the `Apps` heading).
+
+Then, reboot and set PixelLight as the default note taking app in Android's Settings -> Apps -> Default apps -> Notes app.
+
+The `Note-taking` lock screen shortcut will now launch PixelLight.
+
+### Override QR code scanner
+
+Run:
 
 ```bash
 adb shell device_config override systemui default_qr_code_scanner com.chiller3.pixellight/.ToggleActivity

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -36,8 +36,14 @@
             android:name=".ToggleActivity"
             android:exported="true"
             android:showWhenLocked="true"
+            android:turnScreenOn="true"
             android:taskAffinity=""
-            android:theme="@style/android:Theme.NoDisplay" />
+            android:theme="@style/android:Theme.NoDisplay">
+            <intent-filter>
+                <action android:name="android.intent.action.CREATE_NOTE" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
+        </activity>
 
         <service
             android:name=".TorchService"


### PR DESCRIPTION
Android 15 doesn't enable `ROLE_NOTES` by default, but there's a developer option for doing so easily. The user experience when using the note-taking lock screen shortcut is better than overriding the QR code scanner since it doesn't seem to be affected by Android's black background animation bug.

Issue: #12